### PR TITLE
MN_EFA_082_KANUEFB_SYNC_ALWAYS_SHOW_EFB_FIELDS

### DIFF
--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -386,6 +386,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 	private ItemTypeString kanuEfb_urlRequest;
 	private ItemTypeDate kanuEfb_SyncTripsAfterDate;
 	private ItemTypeBoolean kanuEfb_Fullsync;
+	private ItemTypeBoolean kanuEfb_AlwaysShowKanuEFBFields;
 	private ItemTypeMultiSelectList<String> kanuEfb_boatTypes;
 	private ItemTypeBoolean kanuEfb_SyncUnknownBoats;
 	private ItemTypeBoolean kanuEfb_TidyXML;
@@ -1631,6 +1632,9 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 					International.getString("email") + ": " + International.getString("Sicherheit")));
 
 			// ============================= SYNC =============================
+			addParameter(kanuEfb_AlwaysShowKanuEFBFields = new ItemTypeBoolean("kanuEfb_AlwaysShowKanueEFBFields", false, IItemType.TYPE_PUBLIC,
+					BaseTabbedDialog.makeCategory(CATEGORY_SYNC, CATEGORY_KANUEFB), "KanuEFB-Felder in efa immer einblenden"));
+			
 			addParameter(kanuEfb_urlLogin = new ItemTypeString("KanuEfbUrlLogin",
 					"https://efb.kanu-efb.de/services/login", IItemType.TYPE_EXPERT,
 					BaseTabbedDialog.makeCategory(CATEGORY_SYNC, CATEGORY_KANUEFB), "Login URL"));
@@ -2865,6 +2869,10 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 		return kanuEfb_Fullsync.getValue();
 	}
 
+	public Boolean getValueKanuEfb_AlwaysShowKanuEFBFields() {
+		return kanuEfb_AlwaysShowKanuEFBFields.getValue();
+	}
+	
 	public Boolean getValueKanuEfb_SyncUnknownBoats() {
 		return kanuEfb_SyncUnknownBoats.getValue();
 	}

--- a/de/nmichael/efa/data/BoatRecord.java
+++ b/de/nmichael/efa/data/BoatRecord.java
@@ -1132,7 +1132,8 @@ public class BoatRecord extends DataRecord implements IItemFactory, IItemListene
                 IItemType.TYPE_PUBLIC, CAT_MOREDATA, International.getString("von allgemein verfügbaren Statistiken ausnehmen")));
         if (Daten.efaConfig.getValueUseFunctionalityCanoeingGermany()) {
             v.add(item = new ItemTypeString(BoatRecord.EFBID, getEfbId(),
-                    IItemType.TYPE_EXPERT, CAT_MOREDATA, International.onlyFor("Kanu-eFB ID","de")));
+                    (Daten.efaConfig.getValueKanuEfb_AlwaysShowKanuEFBFields() ? IItemType.TYPE_PUBLIC : IItemType.TYPE_EXPERT), 
+                    CAT_MOREDATA, International.onlyFor("Kanu-eFB ID","de")));
         }
 
         // CAT_USAGE

--- a/de/nmichael/efa/data/PersonRecord.java
+++ b/de/nmichael/efa/data/PersonRecord.java
@@ -746,10 +746,12 @@ public class PersonRecord extends DataRecord implements IItemFactory {
                     International.getString("Standard-Boot")));
             item.setFieldSize(300, -1);
             v.add(item = new ItemTypeString(PersonRecord.EXTERNALID, getExternalId(),
-                    IItemType.TYPE_EXPERT, CAT_MOREDATA, International.getString("Externe ID")));
+            		(Daten.efaConfig.getValueKanuEfb_AlwaysShowKanuEFBFields() ? IItemType.TYPE_PUBLIC : IItemType.TYPE_EXPERT), 
+            		CAT_MOREDATA, International.getString("Externe ID")));
             if (Daten.efaConfig.getValueUseFunctionalityCanoeingGermany()) {
                 v.add(item = new ItemTypeString(PersonRecord.EFBID, getEfbId(),
-                        IItemType.TYPE_EXPERT, CAT_MOREDATA, International.onlyFor("Kanu-eFB ID", "de")));
+                		(Daten.efaConfig.getValueKanuEfb_AlwaysShowKanuEFBFields() ? IItemType.TYPE_PUBLIC : IItemType.TYPE_EXPERT), 
+                		CAT_MOREDATA, International.onlyFor("Kanu-eFB ID", "de")));
             }
 
             v.add(item = new ItemTypeString(PersonRecord.ADDRESSSTREET, getAddressStreet(),

--- a/de/nmichael/efa/data/WatersRecord.java
+++ b/de/nmichael/efa/data/WatersRecord.java
@@ -115,7 +115,8 @@ public class WatersRecord extends DataRecord {
         ((ItemTypeTextArea)item).setWrap(true);
         if (Daten.efaConfig.getValueUseFunctionalityCanoeingGermany()) {
             v.add(item = new ItemTypeString(WatersRecord.EFBID, getEfbId(),
-                    IItemType.TYPE_EXPERT, CAT_BASEDATA, International.onlyFor("Kanu-eFB ID","de")));
+            		(Daten.efaConfig.getValueKanuEfb_AlwaysShowKanuEFBFields() ? IItemType.TYPE_PUBLIC : IItemType.TYPE_EXPERT), 
+            		CAT_BASEDATA, International.onlyFor("Kanu-eFB ID","de")));
         }
         return v;
     }


### PR DESCRIPTION
Summary
--------------
New option for Kanu EFB Sync (germany only)
- Configuration -> Synchronisation -> Kanu-EFB Sync "KanuEFB-Felder in EFA immer einblenden"

Diese sorgt dafür, dass bei Personen, Booten, Gewässern, Projekt die KanuEFB-Felder immer sichtbar sind, und nicht erst im Expertenmodus.

Dies vereinfacht die Pflege der EFB-IDs, wenn man diese häufiger eintragen muss.